### PR TITLE
Declare tagsinput as a remote dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,9 @@ Imports:
     shinyjs,
     shinyBS,
     shinycssloaders,
-    readtext,
-    tagsinput
+    readtext
+Remotes:
+    ThinkR-open/tagsinput
 RoxygenNote: 7.0.2
 URL: https://github.com/earnaud/MetaShARK-v2.git
 BugReports: https://github.com/earnaud/MetaShARK-v2.git/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     shinyTree,
     fs,
     mime,
+    shinyAce,
     shinyFiles,
     shinydashboard,
     shinyjs,


### PR DESCRIPTION
tagsinput will not be installed if not placed under DESCRIPTION > Remotes